### PR TITLE
build(npm): switch to local dependencies + update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Getting Started
 
-1. Must install pre-requisites `npm install typescript live-server tsd@0.6.5-beta.2 -g`
-
-1. Fork and clone this repo
+1. Clone this repo
 
 1. `npm install`
 

--- a/package.json
+++ b/package.json
@@ -10,5 +10,10 @@
   "dependencies": {
     "angular2": "2.0.0-alpha.38",
     "systemjs": "0.19.2"
+  },
+  "devDependencies": {
+    "live-server": "0.8.1",
+    "tsd": "0.6.5-beta.2",
+    "typescript": "1.6.2"
   }
 }


### PR DESCRIPTION
Depending on globally installed dependencies is an antipattern that causes problems
when people work on multiple projects that require different versions of typescript
or tsd. Local dependencies should almost always be used.

Local dependencies are also preferred by npm for run scripts, so npm run \* will just
work and will use local dependencies instead of global.
