### PR TITLE
Add RouteConfigMap interface for Routes

### DIFF
--- a/src/app/route.config.ts
+++ b/src/app/route.config.ts
@@ -1,8 +1,13 @@
+import {RouteDefinition} from 'angular2/router';
 import {HeroesComponent} from './heroes.component';
 import {HeroDetailComponent} from './hero-detail.component';
 import {DashboardComponent} from './dashboard.component';
 
-export var Routes = {
+interface RouteConfigMap {
+  [key:string] : RouteDefinition
+}
+
+export var Routes : RouteConfigMap = {
 	dashboard: {
 		path: '/',
     as: 'Dashboard',


### PR DESCRIPTION
Added an interface for configuration of routes in route.config.ts which has `[key:string] : RouteDefinition` type. This helps in autocomplete in editors and in next alpha it will throw error when `as` will be changed to `name`
