### PR TITLE
use catch instead of then

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,7 @@
   <script src="node_modules/angular2/bundles/router.dev.js"></script>
   <script>
       System.config({packages: {app: {format: 'register',defaultExtension: 'js'}}});
-      System.import('app/boot')
-            .then(null, console.error.bind(console));
+      System.import('app/boot').catch(console.error.bind(console));
   </script>
 </head>
 


### PR DESCRIPTION
There is no need to use the `then` function with the first callback set to null, when the second callback (the error one) can be specified using the `catch` function straight forward
