### PR TITLE
Update RXJS dependency to avoid npm install error

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.33.13",
     "reflect-metadata": "0.1.2",
-    "rxjs": "^5.0.0-beta.0",
+    "rxjs": "5.0.0-beta.0",
     "zone.js": "^0.5.10"
   },
   "devDependencies": {


### PR DESCRIPTION
Pinning RXJS to 5.0.0-beta.0 fixes the following error:

npm ERR! peerinvalid The package rxjs does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer angular2@2.0.0-beta.1 wants rxjs@5.0.0-beta.0
