### PR TITLE
Replace lite-server with browser-sync config

### DIFF
--- a/bs-config.js
+++ b/bs-config.js
@@ -1,0 +1,19 @@
+var historyFallback = require('connect-history-api-fallback');
+var log = require('connect-logger');
+/*
+ | For up-to-date information about the options:
+ |   http://www.browsersync.io/docs/options/
+ */
+module.exports = {
+    "files": [
+      './**/*.html', './**/*.css', './**/*.js'
+    ],
+    "server": {
+      "baseDir": './',
+      "middleware": [
+        log(),
+        historyFallback({"index": '/index.html'})
+      ]
+    },
+    "port": 3000
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "tsc": "tsc",
     "tsc:w": "tsc -w",
-    "lite": "lite-server",
+    "lite": "browser-sync start --config bs-config.js",
     "start": "concurrent \"npm run tsc:w\" \"npm run lite\" "
   },
   "dependencies": {
@@ -17,8 +17,10 @@
     "zone.js": "^0.5.10"
   },
   "devDependencies": {
+    "browser-sync": "^2.11.1",
     "concurrently": "^1.0.0",
-    "lite-server": "^1.3.2",
+    "connect-history-api-fallback": "^1.1.0",
+    "connect-logger": "0.0.1",
     "typescript": "^1.7.5"
   }
 }


### PR DESCRIPTION
This PR replaces `lite-server` with `browser-sync` itself, and its external config file feature (`bs-config.js`). 

Since browser-sync supports a `.js` file `require()` for its configuration, we can bake lite-server's extra middleware configuration into the `bs-config.js` file itself. Running browser-sync with the `--config` option will load the config file (see changes in `package.json`).

Please see related PR https://github.com/johnpapa/lite-server/pull/16
