### PR TITLE
chore: hero dashboard initializes first four hero

### DIFF
--- a/app/dashboard.component.ts
+++ b/app/dashboard.component.ts
@@ -20,7 +20,7 @@ export class DashboardComponent implements OnInit {
 
   ngOnInit() {
     this._heroService.getHeroes()
-      .then(heroes => this.heroes = heroes.slice(1,5));
+      .then(heroes => this.heroes = heroes.slice(0,4));
   }
 
   gotoDetail(hero: Hero) {


### PR DESCRIPTION
If we removed down to 2 heroes, the dashboard will only display one hero because it starts at index 1. 
We need to start at index 0. With 2 heroes left, there should be 2 heroes displaying on the dashboard as top heroes.
