### PR TITLE
Fixing AOT Compilation

### DIFF
--- a/tsconfig-aot.json
+++ b/tsconfig-aot.json
@@ -8,14 +8,12 @@
     "experimentalDecorators": true,
     "removeComments": false,
     "noImplicitAny": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "types": []
+    "suppressImplicitAnyIndexErrors": true
   },
 
   "files": [
     "app/app.module.ts",
-    "app/main-aot.ts",
-    "./typings/index.d.ts"
+    "app/main-aot.ts"
   ],
 
   "angularCompilerOptions": {


### PR DESCRIPTION
@johnpapa, it looks like you just missed updating tsconfig-aot.json when you replaced 'typings' in favor of @types.

I removed the typings index from the files array, since it's no longer being generated. That fixes the initial error reported in #93, ```'...angular2-tour-of-heroes/typings/index.d.ts' not found```.

That correction lead to a number of ```Cannot find name 'module'``` follow-on errors. As best I can tell, those were caused by the empty 'types' compiler option, which excluded all @types from compilation.  I removed the 'types' array, so now all @types packages will be automatically included. 

I'm not sure if this fits with what you had in mind. So, of course, feel free to tweak, or let me know if I can correct. 